### PR TITLE
fix base option from head option with `org:`

### DIFF
--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -169,7 +169,7 @@ export default class GithubClient {
 
     return await this.get(this.pullRequestEndpoint(), {
       state: "closed",
-      base: this.head,
+      base: this.head.split(":").at(-1),
       per_page: 100,
       sort: "updated",
       direction: "desc",

--- a/test/github-client.ts
+++ b/test/github-client.ts
@@ -177,6 +177,32 @@ describe("GithubClient", function () {
     });
   });
 
+  describe("#collectReleasePRs(): head option with `org:`", function () {
+    nock("https://api.github.com")
+      .get("/repos/uiureo/awesome-app/pulls/42/commits")
+      .query(true)
+      .reply(200, [])
+      .get(
+        "/repos/uiureo/awesome-app/pulls?state=closed&base=branch&per_page=100&sort=updated&direction=desc"
+      )
+      .reply(200, []);
+
+    it("returns prs that is going to be released", function (done) {
+      const client = new GithubClient({
+        owner: "uiureo",
+        repo: "awesome-app",
+        head: "org:branch",
+      });
+      client
+        .collectReleasePRs({ number: 42 })
+        .then(function (prs) {
+          assert(prs.length === 0);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
   describe("#assignReviewers()", function () {
     const USER1 = "pr1-owner";
     const USER2 = "pr2-owner";


### PR DESCRIPTION
お世話になります。

head引数を`org:branch`と指定したいのですが（そうしないとprepareReleasePR()においてgetした場合、ブランチ名によっては正しく動作せず、意図しないPRに対してupdatePR()が実行されてしまうケースがあるため）、
https://docs.github.com/ja/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests

この指定方法はbase引数では無効のようで、当該箇所でフィルタリングが効きません。

ワークアラウンドとしてはgithubClientオプションを指定するくらいしか見当たりませんでしたので、可能であればご対応いただけると助かります。